### PR TITLE
Remove iOS default <input> style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -94,3 +94,11 @@ input {
 
   font-family: RIDIBatang, serif;
 }
+
+/*  ios default elimination  */
+input[type=text] {
+  /* Remove First */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}


### PR DESCRIPTION
ios에서 input 영역 내부에 그림자가 생기는 문제를 해결합니다. 